### PR TITLE
Add support for the Retro Arcade Mini (RS-07)

### DIFF
--- a/Makefile.amini
+++ b/Makefile.amini
@@ -1,0 +1,78 @@
+TARGET=rs97
+
+CHAINPREFIX := /opt/rs97-toolchain
+CROSS_COMPILE := $(CHAINPREFIX)/usr/bin/mipsel-linux-
+
+BUILDTIME=$(shell date +'\"%Y-%m-%d %H:%M\"')
+
+CC = $(CROSS_COMPILE)gcc
+CXX = $(CROSS_COMPILE)g++
+STRIP = $(CROSS_COMPILE)strip
+
+SYSROOT     := $(shell $(CC) --print-sysroot)
+SDL_CFLAGS  := $(shell $(SYSROOT)/usr/bin/sdl-config --cflags)
+SDL_LIBS    := $(shell $(SYSROOT)/usr/bin/sdl-config --libs --static)
+
+CFLAGS = -ggdb -DTARGET_RS97 -DTARGET=$(TARGET) -DTARGET_ARCADEMINI -D__BUILDTIME__="$(BUILDTIME)" -DLOG_LEVEL=3 -g3 $(SDL_CFLAGS) -I$(CHAINPREFIX)/usr/include/ -I$(SYSROOT)/usr/include/  -I$(SYSROOT)/usr/include/SDL/ -mhard-float -mips32 -mno-mips16
+# -fno-rtti
+CFLAGS += -std=c++11 -fdata-sections -ffunction-sections -fno-exceptions -fno-math-errno -fno-threadsafe-statics -Os
+
+CXXFLAGS = $(CFLAGS)
+# LDFLAGS = $(SDL_LIBS) -lfreetype -lSDL_image -lSDL_ttf -lSDL_gfx -lSDL -lpthread
+LDFLAGS = $(SDL_LIBS) -lfreetype -lSDL_image -lSDL_ttf -lSDL -lpthread
+LDFLAGS +=-Wl,--as-needed -Wl,--gc-sections -s
+
+OBJDIR = objs/$(TARGET)
+DISTDIR = dist/$(TARGET)/gmenu2x
+APPNAME = $(OBJDIR)/gmenu2x
+
+SOURCES := $(wildcard src/*.cpp)
+OBJS := $(patsubst src/%.cpp, $(OBJDIR)/src/%.o, $(SOURCES))
+
+# File types rules
+$(OBJDIR)/src/%.o: src/%.cpp src/%.h
+	$(CXX) $(CFLAGS) -o $@ -c $<
+
+all: dir shared
+
+dir:
+	@if [ ! -d $(OBJDIR)/src ]; then mkdir -p $(OBJDIR)/src; fi
+
+debug: $(OBJS)
+	@echo "Linking gmenu2x-debug..."
+	$(CXX) -o $(APPNAME)-debug $(LDFLAGS) $(OBJS)
+
+shared: debug
+	$(STRIP) $(APPNAME)-debug -o $(APPNAME)
+
+clean:
+	rm -rf $(OBJDIR) $(DISTDIR) *.gcda *.gcno $(APPNAME)
+
+dist: dir shared
+	install -m755 -D $(APPNAME) $(DISTDIR)/gmenu2x
+	install -m644 assets/$(TARGET)/input.conf $(DISTDIR)
+	# install -m755 -d $(DISTDIR)/sections/applications $(DISTDIR)/sections/emulators $(DISTDIR)/sections/games $(DISTDIR)/sections/settings
+	install -m755 -d $(DISTDIR)/sections
+	install -m644 -D README.md $(DISTDIR)/README.txt
+	install -m644 -D COPYING $(DISTDIR)/COPYING
+	install -m644 -D ChangeLog.md $(DISTDIR)/ChangeLog
+	install -m644 -D about.txt $(DISTDIR)/about.txt
+	cp -RH assets/skins assets/translations $(DISTDIR)
+	# cp -RH assets/$(TARGET)/BlackJeans.png $(DISTDIR)/skins/Default/wallpapers
+	# cp -RH assets/$(TARGET)/skin.conf $(DISTDIR)/skins/Default
+	cp -RH assets/$(TARGET)/font.ttf $(DISTDIR)/skins/Default
+	# cp -RH assets/$(TARGET)/gmenu2x.conf $(DISTDIR)
+	#cp -RH assets/$(TARGET)/icons/* $(DISTDIR)/skins/Default/icons/
+	# cp -RH assets/$(TARGET)/emulators/* $(DISTDIR)/sections/emulators/
+	# cp -RH assets/$(TARGET)/games/* $(DISTDIR)/sections/games/
+	# cp -RH assets/$(TARGET)/applications/* $(DISTDIR)/sections/applications/
+	cd $(DISTDIR)/.. && zip -FSr GMenuNX.zip gmenu2x
+
+-include $(patsubst src/%.cpp, $(OBJDIR)/src/%.d, $(SOURCES))
+
+$(OBJDIR)/src/%.d: src/%.cpp
+	@if [ ! -d $(OBJDIR)/src ]; then mkdir -p $(OBJDIR)/src; fi
+	$(CXX) -M $(CXXFLAGS) $< > $@.$$$$; \
+	sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' < $@.$$$$ > $@; \
+	rm -f $@.$$$$
+

--- a/src/gmenu2x.cpp
+++ b/src/gmenu2x.cpp
@@ -285,7 +285,11 @@ GMenu2X::GMenu2X() {
 	SDL_ShowCursor(0);
 #elif defined(TARGET_RS97)
 	SDL_ShowCursor(0);
-	s->ScreenSurface = SDL_SetVideoMode(320, 480, confInt["videoBpp"], SDL_HWSURFACE/*|SDL_DOUBLEBUF*/);
+	#if defined(TARGET_ARCADEMINI)
+	s->ScreenSurface = SDL_SetVideoMode(480, 272, confInt["videoBpp"], SDL_HWSURFACE);
+	#else
+	s->ScreenSurface = SDL_SetVideoMode(320, 480, confInt["videoBpp"], SDL_HWSURFACE);
+	#endif
 	s->raw = SDL_CreateRGBSurface(SDL_SWSURFACE, resX, resY, confInt["videoBpp"], 0, 0, 0, 0);
 #else
 	s->raw = SDL_SetVideoMode(resX, resY, confInt["videoBpp"], SDL_HWSURFACE|SDL_DOUBLEBUF);
@@ -607,7 +611,7 @@ bool GMenu2X::inputCommonActions(bool &inputAction) {
 	if (powerManager->suspendActive) {
 		// SUSPEND ACTIVE
 		input.setWakeUpInterval(0);
-		while (!input[POWER]) {
+		while (!input[POWER] || !input[CANCEL] || !input[CONFIRM]) {
 			input.update();
 		}
 		powerManager->doSuspend(0);

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -176,7 +176,10 @@ void Surface::flip() {
 		// SDL_Flip(dblbuffer);
 	// } else 
 	{
-#if defined(TARGET_RS97)
+#if defined(TARGET_ARCADEMINI)
+	SDL_BlitSurface(raw, NULL, ScreenSurface, NULL);
+	SDL_Flip(ScreenSurface);
+#elif defined(TARGET_RS97)
 	// SDL_SoftStretch(raw, NULL, ScreenSurface, NULL);
 	// SDL_Flip(ScreenSurface);
 	uint32_t *s = (uint32_t*)raw->pixels;


### PR DESCRIPTION
This PR adds proper support for the Retro Arcade Mini. (aka RS-07)
This is basically a tabletop version of the RS-97 1.0S with an LCD screen panel of 480x272 pixels.
Some differences though

- Does not require doubling the lines unlike the RS-97. (which is good) GMenuNx does support the higher resolution as long as resolutionX and resolutionY are set to 480 and 272 respectively.

- There's no power button, it just turns off the unit. There's also seemingly no brightness button.
As a result, there was no way to resume from the suspend mode. I've added the ability to resume from suspend by pressing A or B. You'll have to add a brightness settings in the menu for those without a brightness button on their RS-97 (i broke mine) or the Retro Arcade Mini.

- The unit comes with third party controllers. On the original firmware, you need to plug in those controllers before boot-up. Doing so will disable the buttons on the unit.
This has no effects however using my custom firmware... I hope there's a way to detect additional joysticks, perhaps i'll have to add eudev to the rootfs... An input test app would also be nice.

That's pretty much it.